### PR TITLE
Remove useless deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,11 @@
       "name": "minesweeper",
       "dependencies": {
         "classnames": "2.5.1",
-        "lodash": "4.17.21",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "typescript": "5.7.3",
-        "uuid": "11.0.5",
       },
       "devDependencies": {
-        "@types/lodash": "4.17.15",
         "@types/react": "19.0.10",
         "@types/react-dom": "19.0.4",
         "@vitejs/plugin-react": "4.3.4",
@@ -168,8 +165,6 @@
 
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
-    "@types/lodash": ["@types/lodash@4.17.15", "", {}, "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw=="],
-
     "@types/node": ["@types/node@17.0.5", "", {}, "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw=="],
 
     "@types/react": ["@types/react@19.0.10", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g=="],
@@ -214,8 +209,6 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
-
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
@@ -255,8 +248,6 @@
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.1.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg=="],
-
-    "uuid": ["uuid@11.0.5", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="],
 
     "vite": ["vite@6.1.0", "", { "dependencies": { "esbuild": "^0.24.2", "postcss": "^8.5.1", "rollup": "^4.30.1" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ=="],
 

--- a/package.json
+++ b/package.json
@@ -5,14 +5,11 @@
   "type": "module",
   "dependencies": {
     "classnames": "2.5.1",
-    "lodash": "4.17.21",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "typescript": "5.7.3",
-    "uuid": "11.0.5"
+    "typescript": "5.7.3"
   },
   "devDependencies": {
-    "@types/lodash": "4.17.15",
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
     "@vitejs/plugin-react": "4.3.4",

--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -1,6 +1,4 @@
 import {useReducer} from 'react';
-import lodash from 'lodash';
-import {v4} from 'uuid';
 import {
   getEmptyGrid,
   precomputeSurroundingBombs,
@@ -10,31 +8,43 @@ import {
   checkHasWon,
   setWinningBoard,
   getCellFromCords,
+  iterateOverBoard,
+  getRandomInt,
 } from './Utils';
 import {CellStates, DEFAULT_STATE, ActionTypes} from './Constants';
 import type {GameState, Actions, Dispatch, CellType} from './Types';
 
+let gameCounter = -1;
+
 function gameInitialize(state: GameState = DEFAULT_STATE): GameState {
-  const {rows, columns, bombs} = state;
+  let {rows, columns, bombs} = state;
   let board = getEmptyGrid(rows, columns);
-  lodash(board)
-    .flatten()
-    .filter(
-      ({col, row}: CellType) =>
-        // NOTE: Since the beginning of the game is always a crapshoot and
-        // corners tend to be a good spot to start from, lets ensure there is
-        // never a bomb in a corner
-        !(
-          (col === 0 && row === 0) ||
-          (col === 0 && row === rows - 1) ||
-          (col === columns - 1 && row === rows - 1) ||
-          (col === columns - 1 && row === 0)
-        )
-    )
-    .sampleSize(bombs)
-    .forEach((cell) => (cell.bomb = true));
+  const sampleCells: CellType[] = [];
+  iterateOverBoard(board, (cell, row, col) => {
+    // NOTE: Since the beginning of the game is always a crapshoot and
+    // corners tend to be a good spot to start from, lets ensure there is
+    // never a bomb in a corner
+    if (
+      !(
+        (col === 0 && row === 0) ||
+        (col === 0 && row === rows - 1) ||
+        (col === columns - 1 && row === rows - 1) ||
+        (col === columns - 1 && row === 0)
+      )
+    ) {
+      sampleCells.push(cell);
+    }
+  });
+  while (bombs > 0 && sampleCells.length > 0) {
+    const cell = sampleCells.splice(getRandomInt(sampleCells.length), 1)[0];
+    if (cell == null) {
+      throw new Error('gameInitialize: Cell does not exist');
+    }
+    cell.bomb = true;
+    bombs--;
+  }
   board = precomputeSurroundingBombs(board);
-  return {...state, board, bombsToFlag: bombs, id: v4(), started: false, hasWon: false, gameOver: false};
+  return {...state, board, bombsToFlag: bombs, id: `${++gameCounter}`, started: false, hasWon: false, gameOver: false};
 }
 
 function reducer(state: GameState, action: Actions): GameState {

--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -17,7 +17,7 @@ import type {GameState, Actions, Dispatch, CellType} from './Types';
 let gameCounter = -1;
 
 function gameInitialize(state: GameState = DEFAULT_STATE): GameState {
-  let {rows, columns, bombs} = state;
+  let {rows, columns, bombs, bombs: bombsToFlag} = state;
   let board = getEmptyGrid(rows, columns);
   const sampleCells: CellType[] = [];
   iterateOverBoard(board, (cell, row, col) => {
@@ -44,7 +44,7 @@ function gameInitialize(state: GameState = DEFAULT_STATE): GameState {
     bombs--;
   }
   board = precomputeSurroundingBombs(board);
-  return {...state, board, bombsToFlag: bombs, id: `${++gameCounter}`, started: false, hasWon: false, gameOver: false};
+  return {...state, board, bombsToFlag, id: `${++gameCounter}`, started: false, hasWon: false, gameOver: false};
 }
 
 function reducer(state: GameState, action: Actions): GameState {

--- a/src/Minesweeper.tsx
+++ b/src/Minesweeper.tsx
@@ -1,6 +1,5 @@
 import React, {memo} from 'react';
 import classNames from 'classnames';
-import lodash from 'lodash';
 import FaceButton, {FaceTypes} from './FaceButton';
 import LCDDisplay from './LCDDisplay';
 import Timer from './Timer';
@@ -8,6 +7,7 @@ import Board from './Board';
 import Cell from './Cell';
 import Window from './Window';
 import Menus from './Menus';
+import {iterateOverBoard} from './Utils';
 import {useMinesweeperState} from './Hooks';
 import {ActionTypes} from './Constants';
 import type {GameState, Dispatch} from './Types';
@@ -49,12 +49,13 @@ interface GameBoardProps {
 
 function GameBoard({state, dispatch}: GameBoardProps) {
   const {board, rows, columns, gameOver} = state;
+  const cells: React.ReactNode[] = [];
+  iterateOverBoard(board, (cell) => {
+    cells.push(<MemoizedCell key={`${cell.row}x${cell.col}`} cell={cell} board={board} dispatch={dispatch} />);
+  });
   return (
     <Board rows={rows} columns={columns} disable={gameOver}>
-      {lodash(board)
-        .flatten()
-        .map((cell) => <MemoizedCell key={`${cell.row}x${cell.col}`} cell={cell} board={board} dispatch={dispatch} />)
-        .value()}
+      {cells}
     </Board>
   );
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: {[key: string]: string};
+  export default classes;
+}


### PR DESCRIPTION
I originally depending on some silly deps that just add complexity and overhead, so lets get rid of them.

* `lodash`: This was mostly just a helper to iterate over the board, but the truth is I can easily polyfill this functionality with an iterator function
* `uuid`: This one was pretty dumb, a whole ass library who's job is really just to generate a string that can be used to key new games...